### PR TITLE
Add GitHub user search feature to Tab3 page

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,11 +1,54 @@
-import React from 'react';
-import { IonSearchbar } from '@ionic/react';
+// components/SearchBar.tsx
+import { IonSearchbar, IonList, IonItem, IonAvatar, IonLabel } from '@ionic/react';
+import { useState, useEffect } from 'react';
 
-function Example() {
+const SearchBar: React.FC = () => {
+  const [searchText, setSearchText] = useState('');
+  const [userData, setUserData] = useState<any>(null);
+
+  // Fetch GitHub user data when searchText changes
+  useEffect(() => {
+    if (!searchText) return;
+
+    const timer = setTimeout(() => {
+      fetch(`https://api.github.com/users/${searchText}`)
+        .then(res => res.json())
+        .then(data => setUserData(data))
+        .catch(err => console.log(err));
+    }, 500); // 500ms debounce
+
+    return () => clearTimeout(timer);
+  }, [searchText]);
+
   return (
     <>
-      <IonSearchbar animated={true} placeholder="Animated"></IonSearchbar>
+      <IonSearchbar
+        animated={true}
+        placeholder="Search GitHub username"
+        value={searchText}
+        onIonInput={e => setSearchText(e.detail.value!)}
+      />
+      
+      <IonList>
+        {userData && !userData.message && (
+          <IonItem button onClick={() => window.open(userData.html_url, '_blank')}>
+            <IonAvatar slot="start">
+              <img src={userData.avatar_url} alt="Avatar" />
+            </IonAvatar>
+            <IonLabel>
+              <h2>{userData.login}</h2>
+              <p>{userData.name || 'No full name'}</p>
+            </IonLabel>
+          </IonItem>
+        )}
+        {userData && userData.message && (
+          <IonItem>
+            <IonLabel>User not found</IonLabel>
+          </IonItem>
+        )}
+      </IonList>
     </>
   );
-}
-export default Example;
+};
+
+export default SearchBar;

--- a/src/pages/Tab3.tsx
+++ b/src/pages/Tab3.tsx
@@ -1,3 +1,4 @@
+// pages/Tab3.tsx
 import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/react';
 import SearchBar from '../components/SearchBar';
 import './Tab3.css';
@@ -7,17 +8,12 @@ const Tab3: React.FC = () => {
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle>Search Page</IonTitle>
+          <IonTitle>GitHub Search</IonTitle>
         </IonToolbar>
       </IonHeader>
+
       <IonContent fullscreen>
-        <IonHeader collapse="condense">
-          <IonToolbar>
-            <IonTitle size="large"></IonTitle>
-          </IonToolbar>
-        </IonHeader>
         <SearchBar />
-       
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
### What this PR does
- Adds a SearchBar component that allows searching GitHub usernames
- Fetches user data from GitHub API and displays avatar, login, and name
- Clicking the user opens their GitHub profile in a new tab
- Debounced search implemented to prevent excessive API calls